### PR TITLE
Remove "host_permissions" section from manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,8 +17,5 @@
   "permissions": [
   	"scripting",
   	"storage"
-  	],
-  "host_permissions": [
-  	"https://www.discogs.com/release/*"
   	]
 }


### PR DESCRIPTION
The "host_permissions" section of manifest.json included limitations for Discogs release pages. This is being handled by code. Also, the Chrome extension registration process indicates that extensions with host permissions may take longer to approve, so I'm removing the section since it's redundant.